### PR TITLE
add simple themes function

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,60 @@ There are 2 responsive themes provided with CI3 Fire Starter: 'admin' and 'defau
 built-in parser. If you really wanted to include one, you could check out Phil Sturgeon's CI-Dwoo extension 
 (https://github.com/philsturgeon/codeigniter-dwoo).
 
+####Theme Functions
+
+***add_css_theme( $css_files )***
+
+This function is used to easily add css files to be included in a template. With this function, you can just add css name as parameter and it will use default css path in active theme.
+You can add one or more css files as parameter, either as string or array. If using parameter as string, it must use comma separator between css file name.
+
+**Example:**
+
+	 1. Using string as parameter
+	     $this->add_css_theme( "bootstrap.min.css, style.css, admin.css" );
+	 
+	 2. Using array as parameter
+	     $this->add_css_theme( array( "bootstrap.min.css", "style.css", "admin.css" ) );
+
+***add_js_theme( $js_files, $is_i18n )***
+
+This function is used to easily add js files to be included in a template. With this function, you can just add js name as parameter and it will use default js path in active theme.
+You also can add one or more js files as parameter, either as string or array. If using parameter as string, it must use comma separator between js file name.
+
+The second parameter is used to determine wether js file is support internationalization or not. Default is FALSE.
+
+**Example:**
+
+	 1. Using string as parameter
+	     $this->add_js_theme( "jquery-1.11.1.min.js, bootstrap.min.js, another.js" );
+	 
+	 2. Using array as parameter
+	     $this->add_js_theme( array( "jquery-1.11.1.min.js", "bootstrap.min.js,", "another.js" ) );
+
+
+**add_jsi18n_theme( $js_files )***
+
+This function is used to easily add js files that support internationalization to be included in a template. With this function, you can just add js name as parameter and it will use default js path in active theme.
+You also can add one or more js files as parameter, either as string or array. If using parameter as string, it must use comma separator between js file name.
+
+    1. Using string as parameter
+	    $this->add_jsi18n_theme( "dahboard_i18n.js, contact_i18n.js" );
+	
+	2. Using array as parameter
+	    $this->add_jsi18n_theme( array( "dahboard_i18n.js", "contact_i18n.js" ) );
+	
+	3. Or we can use add_js_theme function, and add **TRUE** for second parameter
+	    $this->add_js_theme( "dahboard_i18n.js, contact_i18n.js", TRUE );
+	     or
+	   $this->add_js_theme( array( "dahboard_i18n.js", "contact_i18n.js" ), TRUE );
+
+With return as chained object we can simply do like this:
+
+    $this
+        ->add_css_theme( "bootstrap.min.css, style.css, admin.css" )
+        ->add_js_theme( "jquery-1.11.1.min.js, bootstrap.min.js, another.js" )
+		->add_js_theme( "dahboard_i18n.js, contact_i18n.js", TRUE );
+
 ##APIS
 
 With the API class, you can quite easily create API functions for external applications. There is no security on these,

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The second parameter is used to determine wether js file is support internationa
 	     $this->add_js_theme( array( "jquery-1.11.1.min.js", "bootstrap.min.js,", "another.js" ) );
 
 
-**add_jsi18n_theme( $js_files )***
+***add_jsi18n_theme( $js_files )***
 
 This function is used to easily add js files that support internationalization to be included in a template. With this function, you can just add js name as parameter and it will use default js path in active theme.
 You also can add one or more js files as parameter, either as string or array. If using parameter as string, it must use comma separator between js file name.
@@ -206,7 +206,7 @@ You also can add one or more js files as parameter, either as string or array. I
 	2. Using array as parameter
 	    $this->add_jsi18n_theme( array( "dahboard_i18n.js", "contact_i18n.js" ) );
 	
-	3. Or we can use add_js_theme function, and add **TRUE** for second parameter
+	3. Or we can use add_js_theme function, and add TRUE for second parameter
 	    $this->add_js_theme( "dahboard_i18n.js, contact_i18n.js", TRUE );
 	     or
 	   $this->add_js_theme( array( "dahboard_i18n.js", "contact_i18n.js" ), TRUE );

--- a/application/controllers/Contact.php
+++ b/application/controllers/Contact.php
@@ -76,9 +76,8 @@ class Contact extends Public_Controller {
         $this->contact_model->save_captcha($captcha_data);
 
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('contact title')
-        ));
+        $this->set_title( lang('contact title') );
+		
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/Profile.php
+++ b/application/controllers/Profile.php
@@ -61,9 +61,8 @@ class Profile extends Private_Controller {
         }
 
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('users title profile')
-        ));
+		$this->set_title( lang('users title profile') );
+		
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -76,9 +76,7 @@ class User extends Public_Controller {
         // setup page header data
 		$this->add_css_theme( 'login.css' );
 		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('users title login'),
-        ));
+        $this->set_title( lang('users title login') );
 		
         $data = $this->includes;
 
@@ -155,9 +153,8 @@ class User extends Public_Controller {
         }
 
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('users title register')
-        ));
+        $this->set_title( lang('users title register') );
+
         $data = $this->includes;
 
         // set content data
@@ -246,9 +243,8 @@ class User extends Public_Controller {
         }
 
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('users title forgot')
-        ));
+        $this->set_title( lang('users title forgot') );
+ 
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -74,12 +74,12 @@ class User extends Public_Controller {
         }
 
         // setup page header data
+		$this->add_css_theme( 'login.css' );
+		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title' => lang('users title login'),
-            'css_files'  => array(
-                '/themes/default/css/login.css'
-            )
         ));
+		
         $data = $this->includes;
 
         // load views

--- a/application/controllers/Welcome.php
+++ b/application/controllers/Welcome.php
@@ -17,9 +17,8 @@ class Welcome extends Public_Controller {
 	function index()
 	{
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => sprintf(lang('core title welcome'), $this->settings->site_name)
-        ));
+        $this->set_title( sprintf(lang('core title welcome'), $this->settings->site_name) );
+ 
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/admin/Contact.php
+++ b/application/controllers/admin/Contact.php
@@ -139,18 +139,17 @@ class Contact extends Admin_Controller {
         ));
 
         // setup page header data
+		$this
+			->add_css_theme( 'bootstrap-datepicker.css' )
+			->add_js_theme( 'bootstrap-datepicker.js' );
+		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title'    => lang('contact title messages_list'),
-            'css_files'     => array(
-                "/themes/admin/css/bootstrap-datepicker.css"
-            ),
-            'js_files'      => array(
-                "/themes/admin/js/bootstrap-datepicker.js"
-            ),
             'js_files_i18n' => array(
                 $this->jsi18n->translate("/themes/admin/js/contact_i18n.js")
             )
         ));
+		
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/admin/Contact.php
+++ b/application/controllers/admin/Contact.php
@@ -141,13 +141,11 @@ class Contact extends Admin_Controller {
         // setup page header data
 		$this
 			->add_css_theme( 'bootstrap-datepicker.css' )
-			->add_js_theme( 'bootstrap-datepicker.js' );
+			->add_js_theme( 'bootstrap-datepicker.js' )
+			->add_js_theme( 'contact_i18n.js', TRUE )
 		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title'    => lang('contact title messages_list'),
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/admin/js/contact_i18n.js")
-            )
         ));
 		
         $data = $this->includes;

--- a/application/controllers/admin/Contact.php
+++ b/application/controllers/admin/Contact.php
@@ -143,10 +143,7 @@ class Contact extends Admin_Controller {
 			->add_css_theme( 'bootstrap-datepicker.css' )
 			->add_js_theme( 'bootstrap-datepicker.js' )
 			->add_js_theme( 'contact_i18n.js', TRUE )
-		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title'    => lang('contact title messages_list'),
-        ));
+			->set_title( lang('contact title messages_list') );
 		
         $data = $this->includes;
 

--- a/application/controllers/admin/Dashboard.php
+++ b/application/controllers/admin/Dashboard.php
@@ -20,11 +20,9 @@ class Dashboard extends Admin_Controller {
     function index()
     {
         // setup page header data
-		$this->add_js_theme( "dashboard_i18n.js", TRUE );
-		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title'    => lang('admin title admin'),
-        ));
+		$this
+			->add_js_theme( "dashboard_i18n.js", TRUE )
+			->set_title( lang('admin title admin') );
 		
         $data = $this->includes;
 

--- a/application/controllers/admin/Dashboard.php
+++ b/application/controllers/admin/Dashboard.php
@@ -20,12 +20,12 @@ class Dashboard extends Admin_Controller {
     function index()
     {
         // setup page header data
+		$this->add_js_theme( "dashboard_i18n.js", TRUE );
+		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title'    => lang('admin title admin'),
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/admin/js/dashboard_i18n.js")
-            )
         ));
+		
         $data = $this->includes;
 
         // load views

--- a/application/controllers/admin/Settings.php
+++ b/application/controllers/admin/Settings.php
@@ -62,13 +62,11 @@ class Settings extends Admin_Controller {
         // setup page header data
 		$this
 			->add_css_theme( 'summernote.css' )
-			->add_js_theme( 'summernote.min.js' );
+			->add_js_theme( 'summernote.min.js' )
+			->add_js_theme( 'settings_i18n.js', TRUE );
 		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title'    => lang('admin settings title'),
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/admin/js/settings_i18n.js")
-            )
         ));
 		
         $data = $this->includes;

--- a/application/controllers/admin/Settings.php
+++ b/application/controllers/admin/Settings.php
@@ -63,11 +63,8 @@ class Settings extends Admin_Controller {
 		$this
 			->add_css_theme( 'summernote.css' )
 			->add_js_theme( 'summernote.min.js' )
-			->add_js_theme( 'settings_i18n.js', TRUE );
-		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title'    => lang('admin settings title'),
-        ));
+			->add_js_theme( 'settings_i18n.js', TRUE )
+			->set_title( lang('admin settings title') );
 		
         $data = $this->includes;
 

--- a/application/controllers/admin/Settings.php
+++ b/application/controllers/admin/Settings.php
@@ -60,18 +60,17 @@ class Settings extends Admin_Controller {
         }
 
         // setup page header data
+		$this
+			->add_css_theme( 'summernote.css' )
+			->add_js_theme( 'summernote.min.js' );
+		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title'    => lang('admin settings title'),
-            'css_files'     => array(
-                "/themes/{$this->settings->theme}/css/summernote.css"
-            ),
-            'js_files'      => array(
-                "/themes/{$this->settings->theme}/js/summernote.min.js"
-            ),
             'js_files_i18n' => array(
                 $this->jsi18n->translate("/themes/admin/js/settings_i18n.js")
             )
         ));
+		
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/admin/Users.php
+++ b/application/controllers/admin/Users.php
@@ -129,12 +129,12 @@ class Users extends Admin_Controller {
         ));
 
         // setup page header data
+		$this->add_js_theme( "users_i18n.js", TRUE );
+		
         $this->includes = array_merge_recursive($this->includes, array(
             'page_title'    => lang('users title user_list'),
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/admin/js/users_i18n.js")
-            )
         ));
+		
         $data = $this->includes;
 
         // set content data

--- a/application/controllers/admin/Users.php
+++ b/application/controllers/admin/Users.php
@@ -129,11 +129,9 @@ class Users extends Admin_Controller {
         ));
 
         // setup page header data
-		$this->add_js_theme( "users_i18n.js", TRUE );
-		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title'    => lang('users title user_list'),
-        ));
+		$this
+			->add_js_theme( "users_i18n.js", TRUE )
+			->set_title( lang('users title user_list') );
 		
         $data = $this->includes;
 
@@ -192,9 +190,8 @@ class Users extends Admin_Controller {
         }
 
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('users title user_add')
-        ));
+        $this->set_title( lang('users title user_add') );
+		
         $data = $this->includes;
 
         // set content data
@@ -262,9 +259,8 @@ class Users extends Admin_Controller {
         }
 
         // setup page header data
-        $this->includes = array_merge_recursive($this->includes, array(
-            'page_title' => lang('users title user_edit')
-        ));
+        $this->set_title( lang('users title user_edit') );
+		
         $data = $this->includes;
 
         // set content data

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -100,6 +100,12 @@ class MY_Controller extends CI_Controller {
 		
 		foreach( $css_files as $css )
 		{
+			// remove white space if any
+			$css = trim( $css );
+			
+			// go to next when passing empty space
+			if ( empty( $css ) ) continue;
+			
 			// using sha1( $css ) as a key to prevent duplicate css to be included
 			$this->includes[ 'css_files' ][ sha1( $css ) ] = base_url( "/themes/{$this->settings->theme}/css" ) . "/{$css}";
 		}
@@ -151,6 +157,12 @@ class MY_Controller extends CI_Controller {
 		
 		foreach( $js_files as $js )
 		{
+			// remove white space if any
+			$js = trim( $js );
+			
+			// go to next when passing empty space
+			if ( empty( $js ) ) continue;
+			
 			// using sha1( $js ) as a key to prevent duplicate js to be included
 			$this->includes[ 'js_files' ][ sha1( $js ) ] = base_url( "/themes/{$this->settings->theme}/js" ) . "/{$js}";
 		}
@@ -199,6 +211,12 @@ class MY_Controller extends CI_Controller {
 		
 		foreach( $js_files as $js )
 		{
+			// remove white space if any
+			$js = trim( $js );
+			
+			// go to next when passing empty space
+			if ( empty( $js ) ) continue;
+			
 			// using sha1( $js ) as a key to prevent duplicate js to be included
 			$this->includes[ 'js_files_i18n' ][ sha1( $js ) ] = $this->jsi18n->translate( "/themes/{$this->settings->theme}/js/{$js}" );
 		}

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -184,7 +184,7 @@ class MY_Controller extends CI_Controller {
 	 * @author	Arif Rahman Hakim
 	 * @since	Version 3.0.5
 	 * @access	public
-	 * @param	mixed
+	 * @param	mixed	
 	 * @return	chained object
 	 */
 	 
@@ -203,6 +203,43 @@ class MY_Controller extends CI_Controller {
 			$this->includes[ 'js_files_i18n' ][ sha1( $js ) ] = $this->jsi18n->translate( "/themes/{$this->settings->theme}/js/{$js}" );
 		}
 
+		return $this;
+	}
+	
+	/* Set Page Title
+	 * --------------------------------------
+	 * @author	Arif Rahman Hakim
+	 * @since	Version 3.0.5
+	 * @access	public
+	 * @param	string
+	 * @return	chained object
+	 */
+	
+	function set_title( $page_title )
+	{
+		$this->includes[ 'page_title' ] = $page_title;
+		
+		/* check wether page_header has been set or has a value 
+		* if not, then set page_title as page_header
+		*/
+		$this->includes[ 'page_header' ] = isset( $this->includes[ 'page_header' ] ) ? $this->includes[ 'page_header' ] : $page_title;
+		return $this;
+	}
+	
+	/* Set Page Header
+	 * sometime, we want to have page header different from page title
+	 * so, use this function
+	 * --------------------------------------
+	 * @author	Arif Rahman Hakim
+	 * @since	Version 3.0.5
+	 * @access	public
+	 * @param	string
+	 * @return	chained object
+	 */
+	
+	function set_page_header( $page_header )
+	{
+		$this->includes[ 'page_header' ] = $page_header;
 		return $this;
 	}
 }

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -116,6 +116,9 @@ class MY_Controller extends CI_Controller {
 	 *
 	 * We can add one or more js files as parameter, either as string or array.
 	 * If using parameter as string, it must use comma separator between js file name.
+	 *
+	 * The second parameter is used to determine wether js file is support internationalization or not.
+	 * Default is FALSE
 	 * -----------------------------------
 	 * Example:
 	 * -----------------------------------
@@ -130,10 +133,62 @@ class MY_Controller extends CI_Controller {
 	 * @since	Version 3.0.5
 	 * @access	public
 	 * @param	mixed
+	 * @param	boolean
 	 * @return	chained object
 	 */
 	 
-	function add_js_theme( $js_files )
+	function add_js_theme( $js_files, $is_i18n = FALSE )
+	{
+		if ( $is_i18n )		
+			return $this->add_jsi18n_theme( $js_files );
+		
+		// make sure that $this->includes has array value
+		if ( ! is_array( $this->includes ) )
+			$this->includes = array();
+		
+		// if $css_files is string, then convert into array
+		$js_files = is_array( $js_files ) ? $js_files : explode( ",", $js_files );
+		
+		foreach( $js_files as $js )
+		{
+			// using sha1( $js ) as a key to prevent duplicate js to be included
+			$this->includes[ 'js_files' ][ sha1( $js ) ] = base_url( "/themes/{$this->settings->theme}/js" ) . "/{$js}";
+		}
+
+		return $this;
+	}
+	
+	/**
+	 * Add JSi18n files from Active Theme Folder
+	 *
+	 * This function used to easily add jsi18n files to be included in a template.
+	 * with this function, we can just add jsi18n name as parameter 
+	 * and it will use default js path in active theme.
+	 *
+	 * We can add one or more jsi18n files as parameter, either as string or array.
+	 * If using parameter as string, it must use comma separator between jsi18n file name.
+	 * -----------------------------------
+	 * Example:
+	 * -----------------------------------
+	 * 1. Using string as parameter
+	 *     $this->add_jsi18n_theme( "dahboard_i18n.js, contact_i18n.js" );
+	 *
+	 * 2. Using array as parameter
+	 *     $this->add_jsi18n_theme( array( "dahboard_i18n.js", "contact_i18n.js" ) );
+	 *
+	 * 3. Or we can use add_js_theme function, and add TRUE for second parameter
+	 *     $this->add_js_theme( "dahboard_i18n.js, contact_i18n.js", TRUE );
+	 *      or
+	 *	   $this->add_js_theme( array( "dahboard_i18n.js", "contact_i18n.js" ), TRUE );
+	 * --------------------------------------
+	 * @author	Arif Rahman Hakim
+	 * @since	Version 3.0.5
+	 * @access	public
+	 * @param	mixed
+	 * @return	chained object
+	 */
+	 
+	function add_jsi18n_theme( $js_files )
 	{
 		// make sure that $this->includes has array value
 		if ( ! is_array( $this->includes ) )
@@ -144,13 +199,12 @@ class MY_Controller extends CI_Controller {
 		
 		foreach( $js_files as $js )
 		{
-			// using sha1( $css ) as a key to prevent duplicate css to be included
-			$this->includes[ 'js_files' ][ sha1( $js ) ] = base_url( "/themes/{$this->settings->theme}/js" ) . "/{$js}";
+			// using sha1( $js ) as a key to prevent duplicate js to be included
+			$this->includes[ 'js_files_i18n' ][ sha1( $js ) ] = $this->jsi18n->translate( base_url( "/themes/{$this->settings->theme}/js" ) ."/{$js}.js" );
 		}
 
 		return $this;
 	}
-	
 }
 
 
@@ -170,14 +224,10 @@ class Public_Controller extends MY_Controller {
         $this->settings->theme = strtolower($this->config->item('public_theme'));
 
         // set up global header data
-		$this->add_css_theme( "{$this->settings->theme}.css" );
+		$this
+			->add_css_theme( "{$this->settings->theme}.css" )
+			->add_js_theme( "{$this->settings->theme}_i18n.js", TRUE );
 
-        $this->includes = array_merge_recursive($this->includes, array(
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/{$this->settings->theme}/js/{$this->settings->theme}_i18n.js")
-            )
-        ));
-;
         // declare main template
         $this->template = "../../htdocs/themes/{$this->settings->theme}/template.php";
     }
@@ -214,13 +264,9 @@ class Private_Controller extends MY_Controller {
         $this->settings->theme = strtolower($this->config->item('public_theme'));
 
         // set up global header data
-		$this->add_css_theme( "{$this->settings->theme}.css" );
-		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/{$this->settings->theme}/js/{$this->settings->theme}_i18n.js")
-            )
-        ));
+		$this
+			->add_css_theme( "{$this->settings->theme}.css" )
+			->add_js_theme( "{$this->settings->theme}_i18n.js", TRUE );
 
         // declare main template
         $this->template = "../../htdocs/themes/{$this->settings->theme}/template.php";
@@ -267,14 +313,10 @@ class Admin_Controller extends MY_Controller {
         $this->settings->theme = strtolower($this->config->item('admin_theme'));
 
         // set up global header data
-		$this->add_css_theme( "{$this->settings->theme}.css,summernote-bs3.css" );
-		$this->add_js_theme( "summernote.min.js" );
-		
-        $this->includes = array_merge_recursive($this->includes, array(
-            'js_files_i18n' => array(
-                $this->jsi18n->translate("/themes/{$this->settings->theme}/js/{$this->settings->theme}_i18n.js")
-            )
-        ));
+		$this
+			->add_css_theme( "{$this->settings->theme}.css,summernote-bs3.css" )
+			->add_js_theme( "summernote.min.js" )
+			->add_js_theme( "{$this->settings->theme}_i18n.js", TRUE );
 
         // declare main template
         $this->template = "../../htdocs/themes/{$this->settings->theme}/template.php";

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -200,7 +200,7 @@ class MY_Controller extends CI_Controller {
 		foreach( $js_files as $js )
 		{
 			// using sha1( $js ) as a key to prevent duplicate js to be included
-			$this->includes[ 'js_files_i18n' ][ sha1( $js ) ] = $this->jsi18n->translate( base_url( "/themes/{$this->settings->theme}/js" ) ."/{$js}.js" );
+			$this->includes[ 'js_files_i18n' ][ sha1( $js ) ] = $this->jsi18n->translate( "/themes/{$this->settings->theme}/js/{$js}" );
 		}
 
 		return $this;

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -83,8 +83,10 @@ class MY_Controller extends CI_Controller {
 	 *
 	 * --------------------------------------
 	 * @author	Arif Rahman Hakim
+	 * @since	Version 3.0.5
 	 * @access	public
 	 * @param	mixed
+	 * @return	chained object
 	 */
 	 
 	function add_css_theme( $css_files )
@@ -125,8 +127,10 @@ class MY_Controller extends CI_Controller {
 	 *
 	 * --------------------------------------
 	 * @author	Arif Rahman Hakim
+	 * @since	Version 3.0.5
 	 * @access	public
 	 * @param	mixed
+	 * @return	chained object
 	 */
 	 
 	function add_js_theme( $js_files )

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -60,7 +60,93 @@ class MY_Controller extends CI_Controller {
         // enable the profiler?
         $this->output->enable_profiler($this->config->item('profiler'));
     }
+	
+	// --------------------------------------------------------------------
 
+	/**
+	 * Add CSS from Active Theme Folder
+	 *
+	 * This function used to easily add css files to be included in a template.
+	 * with this function, we can just add css name as parameter 
+	 * and it will use default css path in active theme.
+	 *
+	 * We can add one or more css files as parameter, either as string or array.
+	 * If using parameter as string, it must use comma separator between css file name.
+	 * -----------------------------------
+	 * Example:
+	 * -----------------------------------
+	 * 1. Using string as parameter
+	 *     $this->add_css_theme( "bootstrap.min.css, style.css, admin.css" );
+	 *
+	 * 2. Using array as parameter
+	 *     $this->add_css_theme( array( "bootstrap.min.css", "style.css", "admin.css" ) );
+	 *
+	 * --------------------------------------
+	 * @author	Arif Rahman Hakim
+	 * @access	public
+	 * @param	mixed
+	 */
+	 
+	function add_css_theme( $css_files )
+	{
+		// make sure that $this->includes has array value
+		if ( ! is_array( $this->includes ) )
+			$this->includes = array();
+		
+		// if $css_files is string, then convert into array
+		$css_files = is_array( $css_files ) ? $css_files : explode( ",", $css_files );
+		
+		foreach( $css_files as $css )
+		{
+			// using sha1( $css ) as a key to prevent duplicate css to be included
+			$this->includes[ 'css_files' ][ sha1( $css ) ] = base_url( "/themes/{$this->settings->theme}/css" ) . "/{$css}";
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Add JS from Active Theme Folder
+	 *
+	 * This function used to easily add js files to be included in a template.
+	 * with this function, we can just add js name as parameter 
+	 * and it will use default js path in active theme.
+	 *
+	 * We can add one or more js files as parameter, either as string or array.
+	 * If using parameter as string, it must use comma separator between js file name.
+	 * -----------------------------------
+	 * Example:
+	 * -----------------------------------
+	 * 1. Using string as parameter
+	 *     $this->add_js_theme( "jquery-1.11.1.min.js, bootstrap.min.js, another.js" );
+	 *
+	 * 2. Using array as parameter
+	 *     $this->add_js_theme( array( "jquery-1.11.1.min.js", "bootstrap.min.js,", "another.js" ) );
+	 *
+	 * --------------------------------------
+	 * @author	Arif Rahman Hakim
+	 * @access	public
+	 * @param	mixed
+	 */
+	 
+	function add_js_theme( $js_files )
+	{
+		// make sure that $this->includes has array value
+		if ( ! is_array( $this->includes ) )
+			$this->includes = array();
+		
+		// if $css_files is string, then convert into array
+		$js_files = is_array( $js_files ) ? $js_files : explode( ",", $js_files );
+		
+		foreach( $js_files as $js )
+		{
+			// using sha1( $css ) as a key to prevent duplicate css to be included
+			$this->includes[ 'js_files' ][ sha1( $js ) ] = base_url( "/themes/{$this->settings->theme}/js" ) . "/{$js}";
+		}
+
+		return $this;
+	}
+	
 }
 
 
@@ -80,15 +166,14 @@ class Public_Controller extends MY_Controller {
         $this->settings->theme = strtolower($this->config->item('public_theme'));
 
         // set up global header data
+		$this->add_css_theme( "{$this->settings->theme}.css" );
+
         $this->includes = array_merge_recursive($this->includes, array(
-            'css_files'     => array(
-                "/themes/{$this->settings->theme}/css/{$this->settings->theme}.css"
-            ),
             'js_files_i18n' => array(
                 $this->jsi18n->translate("/themes/{$this->settings->theme}/js/{$this->settings->theme}_i18n.js")
             )
         ));
-
+;
         // declare main template
         $this->template = "../../htdocs/themes/{$this->settings->theme}/template.php";
     }
@@ -125,10 +210,9 @@ class Private_Controller extends MY_Controller {
         $this->settings->theme = strtolower($this->config->item('public_theme'));
 
         // set up global header data
+		$this->add_css_theme( "{$this->settings->theme}.css" );
+		
         $this->includes = array_merge_recursive($this->includes, array(
-            'css_files'     => array(
-                "/themes/{$this->settings->theme}/css/{$this->settings->theme}.css"
-            ),
             'js_files_i18n' => array(
                 $this->jsi18n->translate("/themes/{$this->settings->theme}/js/{$this->settings->theme}_i18n.js")
             )
@@ -179,14 +263,10 @@ class Admin_Controller extends MY_Controller {
         $this->settings->theme = strtolower($this->config->item('admin_theme'));
 
         // set up global header data
+		$this->add_css_theme( "{$this->settings->theme}.css,summernote-bs3.css" );
+		$this->add_js_theme( "summernote.min.js" );
+		
         $this->includes = array_merge_recursive($this->includes, array(
-            'css_files'     => array(
-                "/themes/{$this->settings->theme}/css/{$this->settings->theme}.css",
-                "/themes/{$this->settings->theme}/css/summernote-bs3.css"
-            ),
-            'js_files'      => array(
-                "/themes/{$this->settings->theme}/js/summernote.min.js"
-            ),
             'js_files_i18n' => array(
                 $this->jsi18n->translate("/themes/{$this->settings->theme}/js/{$this->settings->theme}_i18n.js")
             )

--- a/htdocs/themes/admin/template.php
+++ b/htdocs/themes/admin/template.php
@@ -68,7 +68,7 @@
 
         <?php // Page title ?>
         <div class="page-header">
-            <h1><?php echo $page_title; ?></h1>
+            <h1><?php echo $page_header; ?></h1>
         </div>
 
         <?php // System messages ?>

--- a/htdocs/themes/default/template.php
+++ b/htdocs/themes/default/template.php
@@ -72,7 +72,7 @@
 
         <?php // Page title ?>
         <div class="page-header">
-            <h1><?php echo $page_title; ?></h1>
+            <h1><?php echo $page_header; ?></h1>
         </div>
 
         <?php // System messages ?>


### PR DESCRIPTION
**_add_css_theme( $css_files )**_

This function used to easily add css files to be included in a template. With this function, we can just add css name as parameter and it will use default css path in active theme.

We can add one or more css files as parameter, either as string or array. If using parameter as string, it must use comma separator between css file name.

**Example:**

```
 1. Using string as parameter
     $this->add_css_theme( "bootstrap.min.css, style.css, admin.css" );

 2. Using array as parameter
     $this->add_css_theme( array( "bootstrap.min.css", "style.css", "admin.css" ) );
```

**_add_js_theme( $js_files )**_

This function used to easily add js files to be included in a template. With this function, we can just add js name as parameter and it will use default js path in active theme.

We can add one or more js files as parameter, either as string or array. If using parameter as string, it must use comma separator between js file name.

**Example:**

```
 1. Using string as parameter
     $this->add_js_theme( "jquery-1.11.1.min.js, bootstrap.min.js, another.js" );

 2. Using array as parameter
     $this->add_js_theme( array( "jquery-1.11.1.min.js", "bootstrap.min.js,", "another.js" ) );
```

With return as chained object we can simply do like this:

```
$this
    ->add_css_theme( "bootstrap.min.css, style.css, admin.css" )
    ->add_js_theme( "jquery-1.11.1.min.js, bootstrap.min.js, another.js" );
```
