### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ for the complete list.
 Since version 3.2.4, anytime changes to the database are required, you'll find SQL files in /data/schema\_updates
 
 <a name="conclusion"></a>
-##CONCLUSION
+## CONCLUSION
 
 As I mentioned earlier, CI3 Fire Starter does not attempt to be a full-blown CMS. You would need
 to build that functionality yourself. If you're looking for a full CMS built on CodeIgniter,


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
